### PR TITLE
Build Docker container on top of the Firedrake Vanilla Docker container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM firedrakeproject/firedrake-jupyter:latest
+FROM firedrakeproject/firedrake-vanilla:latest
 
 RUN sudo apt update && sudo apt -y upgrade
 RUN sudo apt install -y cmake gfortran python3-venv default-jre

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/base:jammy
+FROM firedrakeproject/firedrake-jupyter:latest
 
 RUN sudo apt update && sudo apt -y upgrade
 RUN sudo apt install -y cmake gfortran python3-venv default-jre

--- a/install.sh
+++ b/install.sh
@@ -12,4 +12,4 @@ export PATH=${PWD}/tapenade_3.16/bin:${PATH}
 echo "export PATH=${PWD}/tapenade_3.16/bin:${PATH}" >>${HOME}/.bashrc
 
 # Copy over Firedrake notebooks
-cp -r /opt/firedrake/docs/notebooks session2/firedrake/
+cp -r /opt/firedrake/docs/notebooks session2/exercises/firedrake/

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Create a Python virtual environment and pip install all requirements
-python3 -m venv .venv
-source .venv/bin/activate
-echo "source $(pwd)/.venv/bin/activate" >>${HOME}/.bashrc
+# Pip install all requirements
 pip install .
 pip install torch --index-url https://download.pytorch.org/whl/cpu
 
@@ -13,3 +10,6 @@ tar xvf tapenade_3.16.tar
 rm tapenade_3.16.tar
 export PATH=${PWD}/tapenade_3.16/bin:${PATH}
 echo "export PATH=${PWD}/tapenade_3.16/bin:${PATH}" >>${HOME}/.bashrc
+
+# Copy over Firedrake notebooks
+cp -r /opt/firedrake/docs/notebooks session2/firedrake/

--- a/session1/notebook.ipynb
+++ b/session1/notebook.ipynb
@@ -28,7 +28,11 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "# Session 1: Forward mode differentiation and source transformation"
+    "# Session 1: Forward mode differentiation and source transformation\n",
+    "\n",
+    "<div class=\"alert alert-block alert-danger\">\n",
+    "<b>Set up codespace now (it can take a while).</b>\n",
+    "</div>"
    ]
   },
   {

--- a/stripout.sh
+++ b/stripout.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-# Check if .venv is active
-if [[ "${VIRTUAL_ENV}" != *".venv"* ]] || [[ -z "${VIRTUAL_ENV}" ]]; then
-  echo "Error: .venv virtual environment is not active"
-  echo "Please activate it with: source .venv/bin/activate"
-  exit 1
-fi
-
 # Check if nbstripout is installed
 if ! command -v nbstripout &>/dev/null; then
   echo "Error: nbstripout is not installed"


### PR DESCRIPTION
At the end of the second session, I plan to present a showcase of some more advanced AD usage in Firedrake. Originally, I was just going to share my screen, but with the approach proposed in this PR, the attendees will be able to click through the notebooks themselves, too.

In the Firedrake Docker container, packages are just pip installed using the system Python. I think it's fine to adopt the same approach here, so have removed everything related to venv.